### PR TITLE
Pull request for base failure

### DIFF
--- a/dist/microformat-shiv.js
+++ b/dist/microformat-shiv.js
@@ -60,8 +60,8 @@ microformats.Parser.prototype = {
 			}
 			
 			// find base tag to set baseUrl
-			baseTag = dom.querySelectorAll('base');
-			if(baseTag.length > 0) {
+			baseTag = dom.querySelector('base');
+			if(baseTag) {
 				href = this.domUtils.getAttribute(dom, baseTag, 'href');
 				if(href){
 					this.options.baseUrl = href;


### PR DESCRIPTION
This is a fix for issue 9 - shouldn't use querySelector for baseTag.

Other option was to use baseTag[[0], but that seemed wrong since I don't think a document can have more than one base tag.
